### PR TITLE
Fix prefix matching and add unit test

### DIFF
--- a/pkg/flakerunner/processing.go
+++ b/pkg/flakerunner/processing.go
@@ -191,15 +191,28 @@ func (fr *FlakeRunner) ValidateWithControlData(filePath string, controlData *typ
 
 // DetermineTargetTable determines the target table based on S3 prefix
 func (fr *FlakeRunner) DetermineTargetTable(filePath string) (string, *config.PrefixMapping, error) {
-	prefix := extractS3Prefix(filePath)
+	_, key, err := aws.ParseS3Path(filePath)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to parse S3 path %s: %w", filePath, err)
+	}
 
-	for _, mapping := range fr.Config.PrefixMappings {
-		if mapping.S3Prefix == prefix {
-			return mapping.TargetName, &mapping, nil
+	var matched *config.PrefixMapping
+	longest := -1
+	for i := range fr.Config.PrefixMappings {
+		mapping := &fr.Config.PrefixMappings[i]
+		if strings.HasPrefix(key, mapping.S3Prefix) {
+			if len(mapping.S3Prefix) > longest {
+				longest = len(mapping.S3Prefix)
+				matched = mapping
+			}
 		}
 	}
 
-	return "", nil, fmt.Errorf("no prefix mapping found for prefix: %s", prefix)
+	if matched == nil {
+		return "", nil, fmt.Errorf("no prefix mapping found for key: %s", key)
+	}
+
+	return matched.TargetName, matched, nil
 }
 
 // SubmitSparkJob submits a PySpark job to EMR Serverless

--- a/test/prefix_mapping_test.go
+++ b/test/prefix_mapping_test.go
@@ -1,0 +1,27 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/allen13/flake-runner/pkg/config"
+	"github.com/allen13/flake-runner/pkg/flakerunner"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetermineTargetTableNestedPrefix(t *testing.T) {
+	fr := &flakerunner.FlakeRunner{
+		Config: &config.Config{
+			PrefixMappings: []config.PrefixMapping{
+				{S3Prefix: "customers/", TargetName: "CUSTOMERS"},
+				{S3Prefix: "orders/", TargetName: "ORDERS"},
+			},
+		},
+	}
+
+	filePath := "s3://bucket/customers/2024/01/data.csv"
+	target, mapping, err := fr.DetermineTargetTable(filePath)
+	assert.NoError(t, err)
+	assert.Equal(t, "CUSTOMERS", target)
+	assert.NotNil(t, mapping)
+	assert.Equal(t, "customers/", mapping.S3Prefix)
+}


### PR DESCRIPTION
## Summary
- handle nested prefixes when determining target table
- test nested prefix mapping resolution

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684967cd0d848326a54eb03bc0a35094